### PR TITLE
Initial cve command

### DIFF
--- a/src/Valleysoft.Nvd.Client/CveQueryFilter.cs
+++ b/src/Valleysoft.Nvd.Client/CveQueryFilter.cs
@@ -4,11 +4,14 @@ public class CveQueryFilter
 {
     public string? CpeName { get; set; }
     public string? CveId { get; set; }
+    public string? CveTag { get; set; }
     public string? CweId { get; set; }
     public string? CvssV2Metrics { get; set; }
     public string? CvssV3Metrics { get; set; }
+    public string? CvssV4Metrics { get; set; }
     public CvssV2Severity? CvssV2Severity { get; set; }
     public CvssV3Severity? CvssV3Severity { get; set; }
+    public CvssV4Severity? CvssV4Severity { get; set; }
     public bool HasCertAlerts { get; set; }
     public bool HasCertNotes { get; set; }
     public bool HasKev { get; set; }
@@ -27,16 +30,43 @@ public class CveQueryFilter
 
 public enum CvssV2Severity
 {
+    [NvdName("LOW")]
     Low,
+
+    [NvdName("MEDIUM")]
     Medium,
+
+    [NvdName("HIGH")]
     High
 }
 
 public enum CvssV3Severity
 {
+    [NvdName("LOW")]
     Low,
+
+    [NvdName("MEDIUM")]
     Medium,
+
+    [NvdName("HIGH")]
     High,
+
+    [NvdName("CRITICAL")]
+    Critical
+}
+
+public enum CvssV4Severity
+{
+    [NvdName("LOW")]
+    Low,
+
+    [NvdName("MEDIUM")]
+    Medium,
+
+    [NvdName("HIGH")]
+    High,
+
+    [NvdName("CRITICAL")]
     Critical
 }
 
@@ -61,6 +91,9 @@ public class VirtualMatchVersion(string version, VirtualMatchVersionType type)
 
 public enum VirtualMatchVersionType
 {
+    [NvdName("including")]
     Include,
+
+    [NvdName("excluding")]
     Exclude
 }

--- a/src/Valleysoft.Nvd.Client/CveQueryResult.cs
+++ b/src/Valleysoft.Nvd.Client/CveQueryResult.cs
@@ -42,6 +42,9 @@ public class Cve
     [JsonPropertyName("id")]
     public required string Id { get; set; }
 
+    [JsonPropertyName("cveTags")]
+    public CveTag[] Tags { get; set; } = [];
+
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("sourceIdentifier")]
     public string? SourceIdentifier { get; set; }
@@ -101,6 +104,15 @@ public class Cve
 
     [JsonPropertyName("vendorComments")]
     public VendorComment[] VendorComments { get; set; } = [];
+}
+
+public class CveTag
+{
+    [JsonPropertyName("sourceIdentifier")]
+    public required string Source { get; set; }
+
+    [JsonPropertyName("tags")]
+    public string[] Tags { get; set; } = [];
 }
 
 public class VendorComment
@@ -268,7 +280,7 @@ public class CvssV31Score
     public required ScoreType Type { get; set; }
 
     [JsonPropertyName("cvssData")]
-    public required CvssV31ScoreData CvssData { get; set; }
+    public required CvssV40ScoreData CvssData { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     [JsonPropertyName("exploitabilityScore")]
@@ -638,6 +650,41 @@ internal class AttackComplexityTypeConverter : JsonConverter<AttackComplexityTyp
     public static readonly AttackComplexityTypeConverter Singleton = new();
 }
 
+public enum AttackRequirementsType { None, Present };
+
+internal class AttackRequirementsTypeConverter : JsonConverter<AttackRequirementsType>
+{
+    public override bool CanConvert(Type t) => t == typeof(AttackRequirementsType);
+
+    public override AttackRequirementsType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        string? value = reader.GetString();
+        return value switch
+        {
+            "NONE" => AttackRequirementsType.None,
+            "PRESENT" => AttackRequirementsType.Present,
+            _ => throw new Exception("Cannot unmarshal type AttackRequirementsType"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, AttackRequirementsType value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case AttackRequirementsType.None:
+                JsonSerializer.Serialize(writer, "NONE", options);
+                return;
+            case AttackRequirementsType.Present:
+                JsonSerializer.Serialize(writer, "PRESENT", options);
+                return;
+            default:
+                throw new Exception("Cannot marshal type AttackRequirementsType");
+        }
+    }
+
+    public static readonly AttackRequirementsTypeConverter Singleton = new();
+}
+
 public enum AttackVectorType { AdjacentNetwork, Local, Network, Physical };
 
 internal class AttackVectorTypeConverter : JsonConverter<AttackVectorType>
@@ -681,35 +728,35 @@ internal class AttackVectorTypeConverter : JsonConverter<AttackVectorType>
     public static readonly AttackVectorTypeConverter Singleton = new();
 }
 
-public enum AvailabilityImpactEnum { High, Low, None };
+public enum AvailabilityImpactType { High, Low, None };
 
-internal class AvailabilityImpactEnumConverter : JsonConverter<AvailabilityImpactEnum>
+internal class AvailabilityImpactEnumConverter : JsonConverter<AvailabilityImpactType>
 {
-    public override bool CanConvert(Type t) => t == typeof(AvailabilityImpactEnum);
+    public override bool CanConvert(Type t) => t == typeof(AvailabilityImpactType);
 
-    public override AvailabilityImpactEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override AvailabilityImpactType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         string? value = reader.GetString();
         return value switch
         {
-            "HIGH" => AvailabilityImpactEnum.High,
-            "LOW" => AvailabilityImpactEnum.Low,
-            "NONE" => AvailabilityImpactEnum.None,
+            "HIGH" => AvailabilityImpactType.High,
+            "LOW" => AvailabilityImpactType.Low,
+            "NONE" => AvailabilityImpactType.None,
             _ => throw new Exception("Cannot unmarshal type AvailabilityImpactEnum"),
         };
     }
 
-    public override void Write(Utf8JsonWriter writer, AvailabilityImpactEnum value, JsonSerializerOptions options)
+    public override void Write(Utf8JsonWriter writer, AvailabilityImpactType value, JsonSerializerOptions options)
     {
         switch (value)
         {
-            case AvailabilityImpactEnum.High:
+            case AvailabilityImpactType.High:
                 JsonSerializer.Serialize(writer, "HIGH", options);
                 return;
-            case AvailabilityImpactEnum.Low:
+            case AvailabilityImpactType.Low:
                 JsonSerializer.Serialize(writer, "LOW", options);
                 return;
-            case AvailabilityImpactEnum.None:
+            case AvailabilityImpactType.None:
                 JsonSerializer.Serialize(writer, "NONE", options);
                 return;
             default:
@@ -848,6 +895,45 @@ internal class ModifiedAttackComplexityTypeConverter : JsonConverter<ModifiedAtt
                 return;
             default:
                 throw new Exception("Cannot marshal type ModifiedAttackComplexityType");
+        }
+    }
+
+    public static readonly ModifiedAttackComplexityTypeConverter Singleton = new();
+}
+
+public enum ModifiedAttackRequirementsType { None, Present, NotDefined };
+
+internal class ModifiedAttackRequirementsTypeConverter : JsonConverter<ModifiedAttackRequirementsType>
+{
+    public override bool CanConvert(Type t) => t == typeof(ModifiedAttackRequirementsType);
+
+    public override ModifiedAttackRequirementsType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        string? value = reader.GetString();
+        return value switch
+        {
+            "NONE" => ModifiedAttackRequirementsType.None,
+            "PRESENT" => ModifiedAttackRequirementsType.Present,
+            "NOT_DEFINED" => ModifiedAttackRequirementsType.NotDefined,
+            _ => throw new Exception("Cannot unmarshal type ModifiedAttackRequirementsType"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, ModifiedAttackRequirementsType value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case ModifiedAttackRequirementsType.None:
+                JsonSerializer.Serialize(writer, "NONE", options);
+                return;
+            case ModifiedAttackRequirementsType.Present:
+                JsonSerializer.Serialize(writer, "PRESENT", options);
+                return;
+            case ModifiedAttackRequirementsType.NotDefined:
+                JsonSerializer.Serialize(writer, "NOT_DEFINED", options);
+                return;
+            default:
+                throw new Exception("Cannot marshal type ModifiedAttackRequirementsType");
         }
     }
 
@@ -1063,6 +1149,510 @@ internal class ConfidenceTypeConverter : JsonConverter<ConfidenceType>
     }
 
     public static readonly ConfidenceTypeConverter Singleton = new();
+}
+
+public enum VulnerabilityCiaType { None, Low, High };
+
+internal class VulnerabilityCiaTypeConverter : JsonConverter<VulnerabilityCiaType>
+{
+    public override bool CanConvert(Type t) => t == typeof(VulnerabilityCiaType);
+
+    public override VulnerabilityCiaType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        string? value = reader.GetString();
+        return value switch
+        {
+            "NONE" => VulnerabilityCiaType.None,
+            "LOW" => VulnerabilityCiaType.Low,
+            "HIGH" => VulnerabilityCiaType.High,
+            _ => throw new Exception("Cannot unmarshal type VulnerabilityCiaType"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, VulnerabilityCiaType value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case VulnerabilityCiaType.None:
+                JsonSerializer.Serialize(writer, "NONE", options);
+                return;
+            case VulnerabilityCiaType.Low:
+                JsonSerializer.Serialize(writer, "LOW", options);
+                return;
+            case VulnerabilityCiaType.High:
+                JsonSerializer.Serialize(writer, "HIGH", options);
+                return;
+            default:
+                throw new Exception("Cannot marshal type VulnerabilityCiaType");
+        }
+    }
+
+    public static readonly VulnerabilityCiaTypeConverter Singleton = new();
+}
+
+public enum ModifiedVulnerabilityCiaType { None, Low, High, NotDefined };
+
+internal class ModifiedVulnerabilityCiaTypeConverter : JsonConverter<ModifiedVulnerabilityCiaType>
+{
+    public override bool CanConvert(Type t) => t == typeof(ModifiedVulnerabilityCiaType);
+
+    public override ModifiedVulnerabilityCiaType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        string? value = reader.GetString();
+        return value switch
+        {
+            "NONE" => ModifiedVulnerabilityCiaType.None,
+            "LOW" => ModifiedVulnerabilityCiaType.Low,
+            "HIGH" => ModifiedVulnerabilityCiaType.High,
+            "NOT_DEFINED" => ModifiedVulnerabilityCiaType.NotDefined,
+            _ => throw new Exception("Cannot unmarshal type ModifiedVulnerabilityCiaType"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, ModifiedVulnerabilityCiaType value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case ModifiedVulnerabilityCiaType.None:
+                JsonSerializer.Serialize(writer, "NONE", options);
+                return;
+            case ModifiedVulnerabilityCiaType.Low:
+                JsonSerializer.Serialize(writer, "LOW", options);
+                return;
+            case ModifiedVulnerabilityCiaType.High:
+                JsonSerializer.Serialize(writer, "HIGH", options);
+                return;
+            case ModifiedVulnerabilityCiaType.NotDefined:
+                JsonSerializer.Serialize(writer, "NOT_DEFINED", options);
+                return;
+            default:
+                throw new Exception("Cannot marshal type ModifiedVulnerabilityCiaType");
+        }
+    }
+
+    public static readonly ModifiedVulnerabilityCiaTypeConverter Singleton = new();
+}
+
+public enum SubCiaType { None, Low, High };
+
+internal class SubCiaTypeConverter : JsonConverter<SubCiaType>
+{
+    public override bool CanConvert(Type t) => t == typeof(SubCiaType);
+
+    public override SubCiaType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        string? value = reader.GetString();
+        return value switch
+        {
+            "NONE" => SubCiaType.None,
+            "LOW" => SubCiaType.Low,
+            "HIGH" => SubCiaType.High,
+            _ => throw new Exception("Cannot unmarshal type SubCiaType"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, SubCiaType value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case SubCiaType.None:
+                JsonSerializer.Serialize(writer, "NONE", options);
+                return;
+            case SubCiaType.Low:
+                JsonSerializer.Serialize(writer, "LOW", options);
+                return;
+            case SubCiaType.High:
+                JsonSerializer.Serialize(writer, "HIGH", options);
+                return;
+            default:
+                throw new Exception("Cannot marshal type SubCiaType");
+        }
+    }
+
+    public static readonly SubCiaTypeConverter Singleton = new();
+}
+
+public enum ModifiedSubCiaType { Negligible, Low, High, NotDefined };
+
+internal class ModifiedSubCiaTypeConverter : JsonConverter<ModifiedSubCiaType>
+{
+    public override bool CanConvert(Type t) => t == typeof(ModifiedSubCiaType);
+
+    public override ModifiedSubCiaType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        string? value = reader.GetString();
+        return value switch
+        {
+            "NEGLIGIBLE" => ModifiedSubCiaType.Negligible,
+            "LOW" => ModifiedSubCiaType.Low,
+            "HIGH" => ModifiedSubCiaType.High,
+            "NOT_DEFINED" => ModifiedSubCiaType.NotDefined,
+            _ => throw new Exception("Cannot unmarshal type ModifiedSubCiaType"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, ModifiedSubCiaType value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case ModifiedSubCiaType.Negligible:
+                JsonSerializer.Serialize(writer, "NEGLIGIBLE", options);
+                return;
+            case ModifiedSubCiaType.Low:
+                JsonSerializer.Serialize(writer, "LOW", options);
+                return;
+            case ModifiedSubCiaType.High:
+                JsonSerializer.Serialize(writer, "HIGH", options);
+                return;
+            case ModifiedSubCiaType.NotDefined:
+                JsonSerializer.Serialize(writer, "NOT_DEFINED", options);
+                return;
+            default:
+                throw new Exception("Cannot marshal type ModifiedSubCiaType");
+        }
+    }
+
+    public static readonly ModifiedSubCiaTypeConverter Singleton = new();
+}
+
+public enum ModifiedSubIaType { Negligible, Low, High, Safety, NotDefined };
+
+internal class ModifiedSubIaTypeConverter : JsonConverter<ModifiedSubIaType>
+{
+    public override bool CanConvert(Type t) => t == typeof(ModifiedSubIaType);
+
+    public override ModifiedSubIaType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        string? value = reader.GetString();
+        return value switch
+        {
+            "NEGLIGIBLE" => ModifiedSubIaType.Negligible,
+            "LOW" => ModifiedSubIaType.Low,
+            "HIGH" => ModifiedSubIaType.High,
+            "SAFETY" => ModifiedSubIaType.Safety,
+            "NOT_DEFINED" => ModifiedSubIaType.NotDefined,
+            _ => throw new Exception("Cannot unmarshal type ModifiedSubIaType"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, ModifiedSubIaType value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case ModifiedSubIaType.Negligible:
+                JsonSerializer.Serialize(writer, "NEGLIGIBLE", options);
+                return;
+            case ModifiedSubIaType.Low:
+                JsonSerializer.Serialize(writer, "LOW", options);
+                return;
+            case ModifiedSubIaType.High:
+                JsonSerializer.Serialize(writer, "HIGH", options);
+                return;
+            case ModifiedSubIaType.Safety:
+                JsonSerializer.Serialize(writer, "SAFETY", options);
+                return;
+            case ModifiedSubIaType.NotDefined:
+                JsonSerializer.Serialize(writer, "NOT_DEFINED", options);
+                return;
+            default:
+                throw new Exception("Cannot marshal type ModifiedSubIaType");
+        }
+    }
+
+    public static readonly ModifiedSubIaTypeConverter Singleton = new();
+}
+
+public enum ExploitMaturityType { Unreported, ProofOfConcept, Attacked, NotDefined };
+
+internal class ExploitMaturityTypeConverter : JsonConverter<ExploitMaturityType>
+{
+    public override bool CanConvert(Type t) => t == typeof(ExploitMaturityType);
+
+    public override ExploitMaturityType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        string? value = reader.GetString();
+        return value switch
+        {
+            "UNREPORTED" => ExploitMaturityType.Unreported,
+            "PROOF_OF_CONCEPT" => ExploitMaturityType.ProofOfConcept,
+            "ATTACKED" => ExploitMaturityType.Attacked,
+            "NOT_DEFINED" => ExploitMaturityType.NotDefined,
+            _ => throw new Exception("Cannot unmarshal type ExploitMaturityType"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, ExploitMaturityType value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case ExploitMaturityType.Unreported:
+                JsonSerializer.Serialize(writer, "UNREPORTED", options);
+                return;
+            case ExploitMaturityType.ProofOfConcept:
+                JsonSerializer.Serialize(writer, "PROOF_OF_CONCEPT", options);
+                return;
+            case ExploitMaturityType.Attacked:
+                JsonSerializer.Serialize(writer, "ATTACKED", options);
+                return;
+            case ExploitMaturityType.NotDefined:
+                JsonSerializer.Serialize(writer, "NOT_DEFINED", options);
+                return;
+            default:
+                throw new Exception("Cannot marshal type ExploitMaturityType");
+        }
+    }
+
+    public static readonly ExploitMaturityTypeConverter Singleton = new();
+}
+
+public enum SafetyType { Negligible, Present, NotDefined };
+
+internal class SafetyTypeConverter : JsonConverter<SafetyType>
+{
+    public override bool CanConvert(Type t) => t == typeof(SafetyType);
+
+    public override SafetyType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        string? value = reader.GetString();
+        return value switch
+        {
+            "NEGLIGIBLE" => SafetyType.Negligible,
+            "PRESENT" => SafetyType.Present,
+            "NOT_DEFINED" => SafetyType.NotDefined,
+            _ => throw new Exception("Cannot unmarshal type SafetyType"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, SafetyType value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case SafetyType.Negligible:
+                JsonSerializer.Serialize(writer, "NEGLIGIBLE", options);
+                return;
+            case SafetyType.Present:
+                JsonSerializer.Serialize(writer, "PRESENT", options);
+                return;
+            case SafetyType.NotDefined:
+                JsonSerializer.Serialize(writer, "NOT_DEFINED", options);
+                return;
+            default:
+                throw new Exception("Cannot marshal type SafetyType");
+        }
+    }
+
+    public static readonly SafetyTypeConverter Singleton = new();
+}
+
+public enum AutomatableType { NotDefined, No, Yes};
+
+internal class AutomatableTypeConverter : JsonConverter<AutomatableType>
+{
+    public override bool CanConvert(Type t) => t == typeof(AutomatableType);
+
+    public override AutomatableType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        string? value = reader.GetString();
+        return value switch
+        {
+            "NO" => AutomatableType.No,
+            "YES" => AutomatableType.Yes,
+            "NOT_DEFINED" => AutomatableType.NotDefined,
+            _ => throw new Exception("Cannot unmarshal type AutomatableType"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, AutomatableType value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case AutomatableType.No:
+                JsonSerializer.Serialize(writer, "NO", options);
+                return;
+            case AutomatableType.Yes:
+                JsonSerializer.Serialize(writer, "YES", options);
+                return;
+            case AutomatableType.NotDefined:
+                JsonSerializer.Serialize(writer, "NOT_DEFINED", options);
+                return;
+            default:
+                throw new Exception("Cannot marshal type AutomatableType");
+        }
+    }
+
+    public static readonly AutomatableTypeConverter Singleton = new();
+}
+
+public enum RecoveryType { NotDefined, Automatic, User, Irrecoverable };
+
+internal class RecoveryTypeConverter : JsonConverter<RecoveryType>
+{
+    public override bool CanConvert(Type t) => t == typeof(RecoveryType);
+
+    public override RecoveryType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        string? value = reader.GetString();
+        return value switch
+        {
+            "AUTOMATIC" => RecoveryType.Automatic,
+            "USER" => RecoveryType.User,
+            "IRRECOVERABLE" => RecoveryType.Irrecoverable,
+            "NOT_DEFINED" => RecoveryType.NotDefined,
+            _ => throw new Exception("Cannot unmarshal type RecoveryType"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, RecoveryType value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case RecoveryType.Automatic:
+                JsonSerializer.Serialize(writer, "AUTOMATIC", options);
+                return;
+            case RecoveryType.User:
+                JsonSerializer.Serialize(writer, "USER", options);
+                return;
+            case RecoveryType.Irrecoverable:
+                JsonSerializer.Serialize(writer, "IRRECOVERABLE", options);
+                return;
+            case RecoveryType.NotDefined:
+                JsonSerializer.Serialize(writer, "NOT_DEFINED", options);
+                return;
+            default:
+                throw new Exception("Cannot marshal type RecoveryType");
+        }
+    }
+
+    public static readonly RecoveryTypeConverter Singleton = new();
+}
+
+public enum ValueDensityType { NotDefined, Diffuse, Concentrated };
+
+internal class ValueDensityTypeConverter : JsonConverter<ValueDensityType>
+{
+    public override bool CanConvert(Type t) => t == typeof(ValueDensityType);
+
+    public override ValueDensityType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        string? value = reader.GetString();
+        return value switch
+        {
+            "DIFFUSE" => ValueDensityType.Diffuse,
+            "CONCENTRATED" => ValueDensityType.Concentrated,
+            "NOT_DEFINED" => ValueDensityType.NotDefined,
+            _ => throw new Exception("Cannot unmarshal type ValueDensityType"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, ValueDensityType value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case ValueDensityType.Diffuse:
+                JsonSerializer.Serialize(writer, "DIFFUSE", options);
+                return;
+            case ValueDensityType.Concentrated:
+                JsonSerializer.Serialize(writer, "CONCENTRATED", options);
+                return;
+            case ValueDensityType.NotDefined:
+                JsonSerializer.Serialize(writer, "NOT_DEFINED", options);
+                return;
+            default:
+                throw new Exception("Cannot marshal type ValueDensityType");
+        }
+    }
+
+    public static readonly ValueDensityTypeConverter Singleton = new();
+}
+
+public enum VulnerabilityResponseEffortType { NotDefined, Low, Moderate, High };
+
+internal class VulnerabilityResponseEffortTypeConverter : JsonConverter<VulnerabilityResponseEffortType>
+{
+    public override bool CanConvert(Type t) => t == typeof(VulnerabilityResponseEffortType);
+
+    public override VulnerabilityResponseEffortType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        string? value = reader.GetString();
+        return value switch
+        {
+            "LOW" => VulnerabilityResponseEffortType.Low,
+            "MODERATE" => VulnerabilityResponseEffortType.Moderate,
+            "HIGH" => VulnerabilityResponseEffortType.High,
+            "NOT_DEFINED" => VulnerabilityResponseEffortType.NotDefined,
+            _ => throw new Exception("Cannot unmarshal type VulnerabilityResponseEffortType"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, VulnerabilityResponseEffortType value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case VulnerabilityResponseEffortType.Low:
+                JsonSerializer.Serialize(writer, "LOW", options);
+                return;
+            case VulnerabilityResponseEffortType.Moderate:
+                JsonSerializer.Serialize(writer, "MODERATE", options);
+                return;
+            case VulnerabilityResponseEffortType.High:
+                JsonSerializer.Serialize(writer, "HIGH", options);
+                return;
+            case VulnerabilityResponseEffortType.NotDefined:
+                JsonSerializer.Serialize(writer, "NOT_DEFINED", options);
+                return;
+            default:
+                throw new Exception("Cannot marshal type VulnerabilityResponseEffortType");
+        }
+    }
+
+    public static readonly VulnerabilityResponseEffortTypeConverter Singleton = new();
+}
+
+public enum ProviderUrgencyType { NotDefined, Clear, Green, Amber, Red };
+
+internal class ProviderUrgencyTypeConverter : JsonConverter<ProviderUrgencyType>
+{
+    public override bool CanConvert(Type t) => t == typeof(ProviderUrgencyType);
+
+    public override ProviderUrgencyType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        string? value = reader.GetString();
+        return value switch
+        {
+            "CLEAR" => ProviderUrgencyType.Clear,
+            "GREEN" => ProviderUrgencyType.Green,
+            "AMBER" => ProviderUrgencyType.Amber,
+            "RED" => ProviderUrgencyType.Red,
+            "NOT_DEFINED" => ProviderUrgencyType.NotDefined,
+            _ => throw new Exception("Cannot unmarshal type ProviderUrgencyType"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, ProviderUrgencyType value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case ProviderUrgencyType.Clear:
+                JsonSerializer.Serialize(writer, "CLEAR", options);
+                return;
+            case ProviderUrgencyType.Green:
+                JsonSerializer.Serialize(writer, "GREEN", options);
+                return;
+            case ProviderUrgencyType.Amber:
+                JsonSerializer.Serialize(writer, "AMBER", options);
+                return;
+            case ProviderUrgencyType.Red:
+                JsonSerializer.Serialize(writer, "RED", options);
+                return;
+            case ProviderUrgencyType.NotDefined:
+                JsonSerializer.Serialize(writer, "NOT_DEFINED", options);
+                return;
+            default:
+                throw new Exception("Cannot marshal type ProviderUrgencyType");
+        }
+    }
+
+    public static readonly ProviderUrgencyTypeConverter Singleton = new();
 }
 
 public enum ScopeType { Changed, Unchanged };

--- a/src/Valleysoft.Nvd.Client/CvssV2/CvssV2ScoreData.cs
+++ b/src/Valleysoft.Nvd.Client/CvssV2/CvssV2ScoreData.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Globalization;
 
 namespace Valleysoft.Nvd.Client.CvssV2;
 
-public partial class CvssV2ScoreData
+public class CvssV2ScoreData
 {
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("accessComplexity")]

--- a/src/Valleysoft.Nvd.Client/CvssV31/CvssV31ScoreData.cs
+++ b/src/Valleysoft.Nvd.Client/CvssV31/CvssV31ScoreData.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace Valleysoft.Nvd.Client.CvssV31;
 
-public partial class CvssV31ScoreData
+public class CvssV40ScoreData
 {
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("attackComplexity")]
@@ -16,7 +16,7 @@ public partial class CvssV31ScoreData
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("availabilityImpact")]
-    public AvailabilityImpactEnum? AvailabilityImpact { get; set; }
+    public AvailabilityImpactType? AvailabilityImpact { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("availabilityRequirement")]
@@ -31,7 +31,7 @@ public partial class CvssV31ScoreData
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("confidentialityImpact")]
-    public AvailabilityImpactEnum? ConfidentialityImpact { get; set; }
+    public AvailabilityImpactType? ConfidentialityImpact { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("confidentialityRequirement")]
@@ -52,7 +52,7 @@ public partial class CvssV31ScoreData
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("integrityImpact")]
-    public AvailabilityImpactEnum? IntegrityImpact { get; set; }
+    public AvailabilityImpactType? IntegrityImpact { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("integrityRequirement")]
@@ -92,7 +92,7 @@ public partial class CvssV31ScoreData
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("privilegesRequired")]
-    public AvailabilityImpactEnum? PrivilegesRequired { get; set; }
+    public AvailabilityImpactType? PrivilegesRequired { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("remediationLevel")]

--- a/src/Valleysoft.Nvd.Client/CvssV40/CvssV40ScoreData.cs
+++ b/src/Valleysoft.Nvd.Client/CvssV40/CvssV40ScoreData.cs
@@ -2,21 +2,21 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Valleysoft.Nvd.Client.CvssV30;
+namespace Valleysoft.Nvd.Client.CvssV40;
 
-public class CvssV30ScoreData
+public class CvssV40ScoreData
 {
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("attackComplexity")]
     public AttackComplexityType? AttackComplexity { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("attackVector")]
-    public AttackVectorType? AttackVector { get; set; }
+    [JsonPropertyName("attackRequirements")]
+    public AttackRequirementsType? AttackRequirements { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("availabilityImpact")]
-    public AvailabilityImpactType? AvailabilityImpact { get; set; }
+    [JsonPropertyName("attackVector")]
+    public AttackVectorType? AttackVector { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("availabilityRequirement")]
@@ -28,10 +28,6 @@ public class CvssV30ScoreData
 
     [JsonPropertyName("baseSeverity")]
     public SeverityType BaseSeverity { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("confidentialityImpact")]
-    public AvailabilityImpactType? ConfidentialityImpact { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("confidentialityRequirement")]
@@ -47,14 +43,6 @@ public class CvssV30ScoreData
     public SeverityType? EnvironmentalSeverity { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("exploitCodeMaturity")]
-    public ExploitCodeMaturityType? ExploitCodeMaturity { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("integrityImpact")]
-    public AvailabilityImpactType? IntegrityImpact { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("integrityRequirement")]
     public CiaRequirementType? IntegrityRequirement { get; set; }
 
@@ -63,57 +51,48 @@ public class CvssV30ScoreData
     public ModifiedAttackComplexityType? ModifiedAttackComplexity { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("modifiedAttackRequirements")]
+    public ModifiedAttackRequirementsType? ModifiedAttackRequirements { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("modifiedAttackVector")]
     public ModifiedAttackVectorType? ModifiedAttackVector { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("modifiedAvailabilityImpact")]
-    public ModifiedType? ModifiedAvailabilityImpact { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("modifiedConfidentialityImpact")]
-    public ModifiedType? ModifiedConfidentialityImpact { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("modifiedIntegrityImpact")]
-    public ModifiedType? ModifiedIntegrityImpact { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("modifiedPrivilegesRequired")]
     public ModifiedType? ModifiedPrivilegesRequired { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("modifiedScope")]
-    public ModifiedScopeType? ModifiedScope { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("modifiedUserInteraction")]
     public ModifiedUserInteractionType? ModifiedUserInteraction { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("modifiedVulnConfidentialityImpact")]
+    public ModifiedVulnerabilityCiaType? ModifiedVulnerabilityConfidentialityImpact { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("modifiedVulnIntegrityImpact")]
+    public ModifiedVulnerabilityCiaType? ModifiedVulnerabilityIntegrityImpact { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("modifiedVulnAvailabilityImpact")]
+    public ModifiedVulnerabilityCiaType? ModifiedVulnerabilityAvailabilityImpact { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("modifiedSubConfidentialityImpact")]
+    public ModifiedSubCiaType? ModifiedSubConfidentialityImpact { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("modifiedSubIntegrityImpact")]
+    public ModifiedSubIaType? ModifiedSubIntegrityImpact { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("modifiedSubAvailabilityImpact")]
+    public ModifiedSubIaType? ModifiedSubAvailabilityImpact { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("privilegesRequired")]
     public AvailabilityImpactType? PrivilegesRequired { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("remediationLevel")]
-    public RemediationLevelType? RemediationLevel { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("reportConfidence")]
-    public ConfidenceType? ReportConfidence { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("scope")]
-    public ScopeType? Scope { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("temporalScore")]
-    [JsonConverter(typeof(MinMaxValueCheckConverter))]
-    public double? TemporalScore { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("temporalSeverity")]
-    public SeverityType? TemporalSeverity { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("userInteraction")]
@@ -121,6 +100,58 @@ public class CvssV30ScoreData
 
     [JsonPropertyName("vectorString")]
     public required string VectorString { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("vulnConfidentialityImpact")]
+    public VulnerabilityCiaType? VulnerabilityConfidentialityImpact { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("vulnIntegrityImpact")]
+    public VulnerabilityCiaType? VulnerabilityIntegrityImpact { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("vulnAvailabilityImpact")]
+    public VulnerabilityCiaType? VulnerabilityAvailabilityImpact { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("subConfidentialityImpact")]
+    public SubCiaType? SubConfidentialityImpact { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("subIntegrityImpact")]
+    public SubCiaType? SubIntegrityImpact { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("subAvailabilityImpact")]
+    public SubCiaType? SubAvailabilityImpact { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("exploitMaturity")]
+    public ExploitMaturityType? ExploitMaturity { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("Safety")]
+    public SafetyType? Safety { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("Automatable")]
+    public AutomatableType? Automatable { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("Recovery")]
+    public RecoveryType? Recovery { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("valueDensity")]
+    public ValueDensityType? ValueDensity { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("vulnerabilityResponseEffort")]
+    public VulnerabilityResponseEffortType? VulnerabilityResponseEffort { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("providerUrgency")]
+    public ProviderUrgencyType? ProviderUrgency { get; set; }
 
     /// <summary>
     /// CVSS Version

--- a/src/Valleysoft.Nvd.Client/NvdClient.cs
+++ b/src/Valleysoft.Nvd.Client/NvdClient.cs
@@ -1,5 +1,5 @@
 ﻿using System.Net.Http.Json;
-using System.Text;
+using System.Reflection;
 using System.Text.Json;
 
 namespace Valleysoft.Nvd.Client;
@@ -9,15 +9,140 @@ public class NvdClient(HttpClient httpClient, string? apiKey = null)
     private readonly HttpClient _httpClient = httpClient;
     private readonly string? _apiKey = apiKey;
 
-    public async Task<CveQueryResult> GetCves(CveQueryFilter filter, CancellationToken cancellationToken = default)
+    public async Task<CveQueryResult> GetCvesAsync(CveQueryFilter filter, CancellationToken cancellationToken = default)
     {
-        StringBuilder uriParams = new();
-        if (filter.CveId is not null)
+        List<string> uriParams = [];
+
+        if (filter.CpeName is not null)
         {
-            uriParams.Append($"&cveId={filter.CveId}");
+            uriParams.Add($"cpeName={filter.CpeName}");
         }
 
-        string url = $"https://services.nvd.nist.gov/rest/json/cves/2.0?{uriParams}";
+        if (filter.CveId is not null)
+        {
+            uriParams.Add($"cveId={filter.CveId}");
+        }
+
+        if (filter.CveTag is not null)
+        {
+            uriParams.Add($"cveTag={filter.CveTag}");
+        }
+
+        if (filter.CvssV2Metrics is not null)
+        {
+            uriParams.Add($"cvssV2Metrics={filter.CvssV2Metrics}");
+        }
+
+        if (filter.CvssV2Severity is not null)
+        {
+            uriParams.Add($"cvssV2Severity={GetEnumName(filter.CvssV2Severity.Value)}");
+        }
+
+        if (filter.CvssV3Metrics is not null)
+        {
+            uriParams.Add($"cvssV3Metrics={filter.CvssV3Metrics}");
+        }
+
+        if (filter.CvssV3Severity is not null)
+        {
+            uriParams.Add($"cvssV3Severity={GetEnumName(filter.CvssV3Severity.Value)}");
+        }
+
+        if (filter.CvssV4Metrics is not null)
+        {
+            uriParams.Add($"cvssV4Metrics={filter.CvssV4Metrics}");
+        }
+
+        if (filter.CvssV4Severity is not null)
+        {
+            uriParams.Add($"cvssV4Severity={GetEnumName(filter.CvssV4Severity.Value)}");
+        }
+
+        if (filter.CweId is not null)
+        {
+            uriParams.Add($"cweId={filter.CweId}");
+        }
+
+        if (filter.HasCertAlerts)
+        {
+            uriParams.Add("hasCertAlerts");
+        }
+
+        if (filter.HasCertNotes)
+        {
+            uriParams.Add("hasCertNotes");
+        }
+
+        if (filter.HasKev)
+        {
+            uriParams.Add("hasKev");
+        }
+
+        if (filter.IsVulnerable)
+        {
+            uriParams.Add("isVulnerable");
+        }
+
+        if (filter.IsKeywordExactMatch)
+        {
+            uriParams.Add("isKeywordExactMatch");
+        }
+
+        if (filter.Keywords.Length != 0)
+        {
+            uriParams.Add($"keywords={string.Join(' ', filter.Keywords)}");
+        }
+
+        if (filter.LastModified is not null)
+        {
+            uriParams.Add($"lastModStartDate={FormatAsIso8601(filter.LastModified.Value.Start)}");
+            uriParams.Add($"lastModEndDate={FormatAsIso8601(filter.LastModified.Value.End)}");
+        }
+
+        if (filter.ExcludeRejected)
+        {
+            uriParams.Add("noRejected");
+        }
+
+        if (filter.Published is not null)
+        {
+            uriParams.Add($"pubStartDate={FormatAsIso8601(filter.Published.Value.Start)}");
+            uriParams.Add($"pubEndDate={FormatAsIso8601(filter.Published.Value.End)}");
+        }
+
+        if (filter.ResultsPerPage is not null)
+        {
+            uriParams.Add($"resultsPerPage={filter.ResultsPerPage}");
+        }
+
+        if (filter.StartIndex is not null)
+        {
+            uriParams.Add($"startIndex={filter.StartIndex}");
+        }
+
+        if (filter.SourceIdentifier is not null)
+        {
+            uriParams.Add($"sourceIdentifier={filter.SourceIdentifier}");
+        }
+
+        if (filter.VirtualMatch is not null)
+        {
+            uriParams.Add($"virtualMatchString={filter.VirtualMatch.MatchValue}");
+            if (filter.VirtualMatch.StartVersion is not null)
+            {
+                uriParams.Add($"versionStart={filter.VirtualMatch.StartVersion.Version}");
+                uriParams.Add($"versionStartType={GetEnumName(filter.VirtualMatch.StartVersion.Type)}");
+            }
+            if (filter.VirtualMatch.EndVersion is not null)
+            {
+                uriParams.Add($"versionEnd={filter.VirtualMatch.EndVersion.Version}");
+                uriParams.Add($"versionEndType={GetEnumName(filter.VirtualMatch.EndVersion.Type)}");
+            }
+        }
+
+        string uriParamsStr = string.Join('&', uriParams);
+
+        string url = $"https://services.nvd.nist.gov/rest/json/cves/2.0?{uriParamsStr}";
         HttpRequestMessage request = new(HttpMethod.Get, url);
         if (_apiKey is not null)
         {
@@ -29,12 +154,24 @@ public class NvdClient(HttpClient httpClient, string? apiKey = null)
         return result ?? throw new InvalidOperationException("Unable to deserialize the CVE query result.");
     }
 
+    private static string GetEnumName<T>(T enumValue) where T : struct, Enum
+    {
+        string enumName = Enum.GetName(enumValue) ??
+            throw new InvalidOperationException($"Unable to get enum name for value {enumValue} on enum {typeof(T)}.");
+        NvdNameAttribute attrib = typeof(T).GetField(enumName)?.GetCustomAttribute<NvdNameAttribute>() ??
+            throw new InvalidOperationException($"Missing {nameof(NvdNameAttribute)} for value {enumValue} on enum {typeof(T)}.");
+        return attrib.Name;
+    }
+
+    private static string FormatAsIso8601(DateTimeOffset dateTime) => dateTime.ToString("yyyy-MM-ddTHH:mm:ssZ");
+
     private static class Converter
     {
         public static readonly JsonSerializerOptions Settings = new(JsonSerializerDefaults.General)
         {
             Converters =
             {
+                AutomatableTypeConverter.Singleton,
                 ScoreTypeConverter.Singleton,
                 OperatorConverter.Singleton,
                 CvssVersionConverter.Singleton,
@@ -52,18 +189,31 @@ public class NvdClient(HttpClient httpClient, string? apiKey = null)
                 new TimeOnlyConverter(),
                 IsoDateTimeOffsetConverter.Singleton,
                 AttackComplexityTypeConverter.Singleton,
+                AttackRequirementsTypeConverter.Singleton,
                 AttackVectorTypeConverter.Singleton,
                 AvailabilityImpactEnumConverter.Singleton,
                 SeverityTypeConverter.Singleton,
                 ExploitCodeMaturityTypeConverter.Singleton,
+                ExploitMaturityTypeConverter.Singleton,
                 ModifiedAttackComplexityTypeConverter.Singleton,
                 ModifiedAttackVectorTypeConverter.Singleton,
+                ModifiedAttackRequirementsTypeConverter.Singleton,
                 ModifiedTypeConverter.Singleton,
                 ModifiedScopeTypeConverter.Singleton,
+                ModifiedSubCiaTypeConverter.Singleton,
+                ModifiedSubIaTypeConverter.Singleton,
                 ModifiedUserInteractionTypeConverter.Singleton,
+                ModifiedVulnerabilityCiaTypeConverter.Singleton,
+                ProviderUrgencyTypeConverter.Singleton,
                 ConfidenceTypeConverter.Singleton,
+                RecoveryTypeConverter.Singleton,
+                SafetyTypeConverter.Singleton,
                 ScopeTypeConverter.Singleton,
-                UserInteractionTypeConverter.Singleton
+                SubCiaTypeConverter.Singleton,
+                UserInteractionTypeConverter.Singleton,
+                ValueDensityTypeConverter.Singleton,
+                VulnerabilityCiaTypeConverter.Singleton,
+                VulnerabilityResponseEffortTypeConverter.Singleton,
             }
         };
     }

--- a/src/Valleysoft.Nvd.Client/NvdNameAttribute.cs
+++ b/src/Valleysoft.Nvd.Client/NvdNameAttribute.cs
@@ -1,0 +1,7 @@
+﻿namespace Valleysoft.Nvd.Client;
+
+[AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
+internal class NvdNameAttribute(string name) : Attribute
+{
+    public string Name { get; } = name;
+}

--- a/src/Valleysoft.NvdExplorer/Commands/CommandWithOptions.cs
+++ b/src/Valleysoft.NvdExplorer/Commands/CommandWithOptions.cs
@@ -1,0 +1,25 @@
+﻿using System.CommandLine;
+using System.CommandLine.Invocation;
+
+namespace Valleysoft.NvdExplorer.Commands;
+
+public abstract class CommandWithOptions<TOptions> : Command
+    where TOptions : OptionsBase, new()
+{
+    public new TOptions Options { get; set; } = new();
+
+    protected CommandWithOptions(string name, string description)
+        : base(name, description)
+    {
+        Options.SetCommandOptions(this);
+        this.SetHandler(ExecuteAsyncCore);
+    }
+
+    private async Task ExecuteAsyncCore(InvocationContext context)
+    {
+        Options.SetParseResult(context.BindingContext.ParseResult);
+        await ExecuteAsync();
+    }
+
+    protected abstract Task ExecuteAsync();
+}

--- a/src/Valleysoft.NvdExplorer/Commands/CveCommand.cs
+++ b/src/Valleysoft.NvdExplorer/Commands/CveCommand.cs
@@ -1,0 +1,58 @@
+﻿using System.CommandLine;
+using System.Text.Json;
+using Valleysoft.Nvd.Client;
+
+namespace Valleysoft.NvdExplorer.Commands;
+
+internal class CveCommand(NvdClient client, IConsole console) : CommandWithOptions<CveOptions>("cve", "Queries for one or more CVEs")
+{
+    private const int MaxResultsPerRequest = 2000;
+    private readonly NvdClient _client = client;
+    private readonly IConsole _console = console;
+    private readonly JsonSerializerOptions _options = new()
+    {
+        WriteIndented = true
+    };
+
+    protected override async Task ExecuteAsync()
+    {
+        CveQueryFilter filter = new()
+        {
+            CveId = Options.Id,
+            CpeName = Options.Cpe,
+            CveTag = Options.Tag,
+            CvssV2Metrics = Options.CvssV2Metrics,
+            CvssV2Severity = Options.CvssV2Severity,
+            CvssV3Metrics = Options.CvssV3Metrics,
+            CvssV3Severity = Options.CvssV3Severity,
+            CvssV4Metrics = Options.CvssV4Metrics,
+            CvssV4Severity = Options.CvssV4Severity,
+        };
+
+        if (Options.Limit is not null)
+        {
+            filter.ResultsPerPage = Math.Min(Options.Limit.Value, MaxResultsPerRequest);
+        }
+
+        int totalReturnedCount = 0;
+        List<Cve> vulnerabilities = [];
+        CveQueryResult result;
+
+        do
+        {
+            result = await _client.GetCvesAsync(filter);
+            totalReturnedCount += result.Vulnerabilities.Length;
+            vulnerabilities.AddRange(result.Vulnerabilities.Select(vuln => vuln.Cve));
+            filter.StartIndex = totalReturnedCount;
+
+            if (Options.Limit is not null)
+            {
+                filter.ResultsPerPage = Math.Min(Options.Limit.Value - totalReturnedCount, MaxResultsPerRequest);
+            }
+            
+        } while (totalReturnedCount < result.TotalResults && totalReturnedCount < Options.Limit);
+
+        string json = JsonSerializer.Serialize(vulnerabilities, _options);
+        _console.WriteLine(json);
+    }
+}

--- a/src/Valleysoft.NvdExplorer/Commands/CveOptions.cs
+++ b/src/Valleysoft.NvdExplorer/Commands/CveOptions.cs
@@ -1,0 +1,109 @@
+﻿using System.CommandLine;
+using System.Runtime.CompilerServices;
+using Valleysoft.Nvd.Client;
+
+namespace Valleysoft.NvdExplorer.Commands;
+
+internal class CveOptions : OptionsBase
+{
+    private readonly Option<int?> _limitOption;
+    private readonly Option<string?> _cpeOption;
+    private readonly Option<string?> _idOption;
+    private readonly Option<string?> _tagOption;
+    private readonly Option<string?> _cvssV2MetricsOption;
+    private readonly Option<CvssV2Severity?> _cvssV2SeverityOption;
+    private readonly Option<string?> _cvssV3MetricsOption;
+    private readonly Option<CvssV3Severity?> _cvssV3SeverityOption;
+    private readonly Option<string?> _cvssV4MetricsOption;
+    private readonly Option<CvssV4Severity?> _cvssV4SeverityOption;
+    private readonly Option<string?> _cweIdOption;
+    private readonly Option<bool> _hasCertAlertsOption;
+    private readonly Option<bool> _hasCertNotesOption;
+    private readonly Option<bool> _hasKevOption;
+    private readonly Option<bool> _hasOvalOption;
+    private readonly Option<bool> _isVulnerableOption;
+    private readonly Option<string> _keywordSearchOption;
+    private readonly Option<bool> _keywordExactMatchOption;
+
+    public int? Limit { get; set; }
+
+    public string? Cpe { get; set; }
+
+    public string? Id { get; set; }
+
+    public string? Tag { get; set; }
+
+    public string? CvssV2Metrics { get; set; }
+
+    public CvssV2Severity? CvssV2Severity { get; set; }
+
+    public string? CvssV3Metrics { get; set; }
+
+    public CvssV3Severity? CvssV3Severity { get; set; }
+
+    public string? CvssV4Metrics { get; set; }
+
+    public CvssV4Severity? CvssV4Severity { get; set; }
+
+    public string? CweId { get; set; }
+
+    public bool HasCertAlerts { get; set; }
+
+    public bool HasCertNotes { get; set; }
+
+    public bool HasKev { get; set; }
+
+    public bool HasOval { get; set; }
+
+    public bool IsVulnerable { get; set; }
+
+    public string? KeywordSearch { get; set; }
+
+
+    public CveOptions()
+    {
+        const string CpeOptionName = "--cpe";
+        const string KeywordsOptionName = "--keywords";
+
+
+        _limitOption = Add(new Option<int?>("--limit", "Maximum number of CVEs to include in the result"));
+        _cpeOption = Add(new Option<string?>(CpeOptionName, "Returns CVEs associated with a specific Common Platform Enumeration (CPE) name"));
+        _idOption = Add(new Option<string?>("--cve", "Returns a CVE by its CVE ID"));
+        _tagOption = Add(new Option<string?>("--tag", "Returns CVEs that include the provided tag"));
+        _cvssV2MetricsOption = Add(new Option<string?>("--cvss-v2", "Returns CVEs that match the provided CVSS v2 vector string"));
+        _cvssV2SeverityOption = Add(new Option<CvssV2Severity?>("--cvss-v2-severity", "Returns CVEs that match the provided CVSS v2 qualitative severity rating"));
+        _cvssV3MetricsOption = Add(new Option<string?>("--cvss-v3", "Returns CVEs that match the provided CVSS v3 vector string"));
+        _cvssV3SeverityOption = Add(new Option<CvssV3Severity?>("--cvss-v3-severity", "Returns CVEs that match the provided CVSS v3 qualitative severity rating"));
+        _cvssV4MetricsOption = Add(new Option<string?>("--cvss-v4", "Returns CVEs that match the provided CVSS v4 vector string"));
+        _cvssV4SeverityOption = Add(new Option<CvssV4Severity?>("--cvss-v4-severity", "Returns CVEs that match the provided CVSS v4 qualitative severity rating"));
+        _cweIdOption = Add(new Option<string?>("--cwe", "Returns CVEs that include a weakness identified by the Common Weakness Enumeration (CWE) ID"));
+        _hasCertAlertsOption = Add(new Option<bool>("--cert-alerts", "Returns CVEs that contain a Technical Alert from US-CERT"));
+        _hasCertNotesOption = Add(new Option<bool>("--cert-notes", "Returns CVEs that contain a Vulnerability Note from CERT/CC"));
+        _hasKevOption = Add(new Option<bool>("--kev", "Returns CVEs that appear in CISA's Known Exploited Vulnerabilities (KEV) Catalog"));
+        _hasOvalOption = Add(new Option<bool>("--oval", "Returns CVEs that contain information from MITRE's Open Vulnerability and Assessment Language (OVAL)"));
+        _isVulnerableOption = Add(new Option<bool>("--vulnerable", $"Returns CVEs associated with a CPE that is considered vulnerable (must be used with {CpeOptionName})"));
+        _keywordSearchOption = Add(new Option<string>(KeywordsOptionName, "Returns CVEs that contain the provided keywords in the description"));
+        _keywordExactMatchOption = Add(new Option<bool>("--exact-match", $"Modifies the keyword search to find an exact match (must be used with {KeywordsOptionName})"));
+    }
+
+    protected override void GetValues()
+    {
+        Limit = GetValue(_limitOption);
+        Cpe = GetValue(_cpeOption);
+        Id = GetValue(_idOption);
+        Tag = GetValue(_tagOption);
+        CvssV2Metrics = GetValue(_cvssV2MetricsOption);
+        CvssV2Severity = GetValue(_cvssV2SeverityOption);
+        CvssV3Metrics = GetValue(_cvssV3MetricsOption);
+        CvssV3Severity = GetValue(_cvssV3SeverityOption);
+        CvssV4Metrics = GetValue(_cvssV4MetricsOption);
+        CvssV4Severity = GetValue(_cvssV4SeverityOption);
+        CweId = GetValue(_cweIdOption);
+        HasCertAlerts = GetValue(_hasCertAlertsOption);
+        HasCertNotes = GetValue(_hasCertNotesOption);
+        HasKev = GetValue(_hasKevOption);
+        HasOval = GetValue(_hasOvalOption);
+        IsVulnerable = GetValue(_isVulnerableOption);
+        KeywordSearch = GetValue(_keywordSearchOption);
+    }
+}

--- a/src/Valleysoft.NvdExplorer/Commands/OptionsBase.cs
+++ b/src/Valleysoft.NvdExplorer/Commands/OptionsBase.cs
@@ -1,0 +1,67 @@
+﻿using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Valleysoft.NvdExplorer.Commands;
+
+public abstract class OptionsBase
+{
+    private readonly List<Argument> _arguments = [];
+    private readonly List<Option> _options = [];
+    private ParseResult? _parseResult;
+
+    protected Argument<T> Add<T>(Argument<T> argument)
+    {
+        _arguments.Add(argument);
+        return argument;
+    }
+
+    protected Option<T> Add<T>(Option<T> option)
+    {
+        _options.Add(option);
+        return option;
+    }
+
+    protected T GetValue<T>(Argument<T> arg)
+    {
+        ValidateParseResult();
+        return _parseResult.GetValueForArgument(arg);
+    }
+
+    protected T? GetValue<T>(Option<T> option)
+    {
+        ValidateParseResult();
+        return _parseResult.GetValueForOption(option);
+    }
+
+    [MemberNotNull(nameof(_parseResult))]
+    private void ValidateParseResult()
+    {
+        if (_parseResult is null)
+        {
+            throw new Exception($"'{nameof(SetParseResult)}' method must be called before get argument value");
+        }
+    }
+
+    public void SetParseResult(ParseResult parseResult)
+    {
+        _parseResult = parseResult;
+        GetValues();
+    }
+
+    protected abstract void GetValues();
+
+    public void SetCommandOptions(Command cmd)
+    {
+        foreach (Argument arg in _arguments)
+        {
+            cmd.AddArgument(arg);
+        }
+
+        foreach (Option option in _options)
+        {
+            cmd.AddOption(option);
+        }
+    }
+}
+

--- a/src/Valleysoft.NvdExplorer/Program.cs
+++ b/src/Valleysoft.NvdExplorer/Program.cs
@@ -1,10 +1,16 @@
-﻿using Valleysoft.Nvd.Client;
+﻿using System.CommandLine;
+using System.CommandLine.IO;
+using Valleysoft.Nvd.Client;
+using Valleysoft.NvdExplorer.Commands;
 
-string apiKey = "<api-key>";
+string? apiKey = Environment.GetEnvironmentVariable("NVD_EXPLORER_API_KEY");
 
-string cveId = "<cve>";
-using HttpClient client = new();
-NvdClient nvdClient = new(client, apiKey);
-CveQueryResult cveQueryResult = await nvdClient.GetCves(new CveQueryFilter { CveId = cveId });
-SeverityType severity = cveQueryResult.Vulnerabilities.First().Cve.Metrics!.CvssMetricV31.First().CvssData.BaseSeverity;
-Console.WriteLine($"{cveId}: {severity}");
+NvdClient client = new(new HttpClient(), apiKey);
+SystemConsole console = new();
+
+RootCommand rootCommand = new("CLI for querying National Vulnerability Database (NVD)")
+{
+    new CveCommand(client, console)
+};
+
+return rootCommand.Invoke(args);

--- a/src/Valleysoft.NvdExplorer/Properties/launchSettings.json
+++ b/src/Valleysoft.NvdExplorer/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Valleysoft.NvdExplorer": {
+        "commandName": "Project",
+        "commandLineArgs": "cve --limit 5 --cvss-v4 AV:A/AC:H/PR:H/UI:N"
+    }
+  }
+}

--- a/src/Valleysoft.NvdExplorer/Valleysoft.NvdExplorer.csproj
+++ b/src/Valleysoft.NvdExplorer/Valleysoft.NvdExplorer.csproj
@@ -15,4 +15,8 @@
     <EditorConfigFiles Remove="C:\repos\NVDExplorer\src\Valleysoft.NvdExplorer\.editorconfig" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Defines a `cve` command that provides a command-line interface for querying the National Vulnerability Database (NVD) for Common Vulnerabilities and Exposures (CVE) data.

Only a partial set of the options are currently defined amongst the full set of filters available from the REST API.