### PR TITLE
Initial cpe command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+launchSettings.json
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/src/Valleysoft.Nvd.Client/CpeQueryFilter.cs
+++ b/src/Valleysoft.Nvd.Client/CpeQueryFilter.cs
@@ -1,0 +1,10 @@
+﻿namespace Valleysoft.Nvd.Client;
+
+public class CpeQueryFilter
+{
+    public int? ResultsPerPage { get; set; }
+    public int? StartIndex { get; set; }
+
+    public string? Keywords { get; set; }
+    public bool IsKeywordExactMatch { get; set; }
+}

--- a/src/Valleysoft.Nvd.Client/CpeQueryResult.cs
+++ b/src/Valleysoft.Nvd.Client/CpeQueryResult.cs
@@ -1,0 +1,47 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Valleysoft.Nvd.Client;
+
+public class CpeQueryResult : QueryResult
+{
+    [JsonPropertyName("products")]
+    public Product[] Products { get; set; } = [];
+}
+
+public class Product
+{
+    [JsonPropertyName("cpe")]
+    public required Cpe Cpe { get; set; }
+}
+
+public class Cpe
+{
+    [JsonPropertyName("deprecated")]
+    public bool IsDeprecated { get; set; }
+
+    [JsonPropertyName("cpeName")]
+    public required string CpeName { get; set; }
+
+    [JsonPropertyName("cpeNameId")]
+    public required string CpeNameId { get; set; }
+
+    [JsonPropertyName("lastModified")]
+    public required DateTimeOffset LastModified { get; set; }
+
+    [JsonPropertyName("created")]
+    public required DateTimeOffset Created { get; set; }
+
+    [JsonPropertyName("titles")]
+    public CpeTitle[] Titles { get; set; } = [];
+}
+
+public class CpeTitle : ILanguageValue
+{
+    [JsonPropertyName("title")]
+    public required string Title { get; set; }
+
+    [JsonPropertyName("lang")]
+    public required string Language { get; set; }
+
+    string ILanguageValue.Value => Title;
+}

--- a/src/Valleysoft.Nvd.Client/CveQueryResult.cs
+++ b/src/Valleysoft.Nvd.Client/CveQueryResult.cs
@@ -7,26 +7,8 @@ using Valleysoft.Nvd.Client.CvssV31;
 
 namespace Valleysoft.Nvd.Client;
 
-public class CveQueryResult
+public class CveQueryResult : QueryResult
 {
-    [JsonPropertyName("resultsPerPage")]
-    public required int ResultsPerPage { get; set; }
-
-    [JsonPropertyName("startIndex")]
-    public required int StartIndex { get; set; }
-
-    [JsonPropertyName("totalResults")]
-    public required int TotalResults { get; set; }
-
-    [JsonPropertyName("format")]
-    public required string Format { get; set; }
-
-    [JsonPropertyName("version")]
-    public required string Version { get; set; }
-
-    [JsonPropertyName("timestamp")]
-    public required DateTimeOffset Timestamp { get; set; }
-
     [JsonPropertyName("vulnerabilities")]
     public required Vulnerability[] Vulnerabilities { get; set; } = [];
 }
@@ -88,7 +70,7 @@ public class Cve
     public string? CisaVulnerabilityName { get; set; }
 
     [JsonPropertyName("descriptions")]
-    public required LanguageString[] Descriptions { get; set; } = [];
+    public required LanguageValue[] Descriptions { get; set; } = [];
 
     [JsonPropertyName("references")]
     public required Reference[] References { get; set; } = [];
@@ -194,10 +176,10 @@ public class Weakness
     public required string Type { get; set; }
 
     [JsonPropertyName("description")]
-    public required LanguageString[] Description { get; set; } = [];
+    public required LanguageValue[] Description { get; set; } = [];
 }
 
-public class LanguageString
+public class LanguageValue : ILanguageValue
 {
     [JsonPropertyName("lang")]
     public required string Language { get; set; }

--- a/src/Valleysoft.Nvd.Client/ILanguageValue.cs
+++ b/src/Valleysoft.Nvd.Client/ILanguageValue.cs
@@ -1,0 +1,7 @@
+﻿namespace Valleysoft.Nvd.Client;
+
+public interface ILanguageValue
+{
+    string Language { get; }
+    string Value { get; }
+}

--- a/src/Valleysoft.Nvd.Client/QueryResult.cs
+++ b/src/Valleysoft.Nvd.Client/QueryResult.cs
@@ -1,0 +1,24 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Valleysoft.Nvd.Client;
+
+public abstract class QueryResult
+{
+    [JsonPropertyName("resultsPerPage")]
+    public required int ResultsPerPage { get; set; }
+
+    [JsonPropertyName("startIndex")]
+    public required int StartIndex { get; set; }
+
+    [JsonPropertyName("totalResults")]
+    public required int TotalResults { get; set; }
+
+    [JsonPropertyName("format")]
+    public required string Format { get; set; }
+
+    [JsonPropertyName("version")]
+    public required string Version { get; set; }
+
+    [JsonPropertyName("timestamp")]
+    public required DateTimeOffset Timestamp { get; set; }
+}

--- a/src/Valleysoft.NvdExplorer/Commands/CpeCommand.cs
+++ b/src/Valleysoft.NvdExplorer/Commands/CpeCommand.cs
@@ -1,0 +1,78 @@
+﻿using System.CommandLine;
+using System.Globalization;
+using System.Text.Json;
+using Valleysoft.Nvd.Client;
+
+namespace Valleysoft.NvdExplorer.Commands;
+
+internal class CpeCommand(NvdClient client, IConsole console) : CommandWithOptions<CpeOptions>("cpe", "Queries for one or more CPEs")
+{
+    private const int MaxResultsPerRequest = 10000;
+    private readonly NvdClient _client = client;
+    private readonly IConsole _console = console;
+    private readonly JsonSerializerOptions _options = new()
+    {
+        WriteIndented = true
+    };
+
+    protected override async Task ExecuteAsync()
+    {
+        CpeQueryFilter filter = new()
+        {
+            Keywords = Options.KeywordSearch,
+            IsKeywordExactMatch = Options.IsKeywordExactMatch,
+        };
+
+        if (Options.Limit is not null)
+        {
+            filter.ResultsPerPage = Math.Min(Options.Limit.Value, MaxResultsPerRequest);
+        }
+
+        int totalReturnedCount = 0;
+        List<Cpe> cpes = [];
+        CpeQueryResult result;
+
+        do
+        {
+            result = await _client.GetCpesAsync(filter);
+            totalReturnedCount += result.Products.Length;
+            cpes.AddRange(result.Products.Select(product => product.Cpe));
+            filter.StartIndex = totalReturnedCount;
+
+            if (Options.Limit is not null)
+            {
+                filter.ResultsPerPage = Math.Min(Options.Limit.Value - totalReturnedCount, MaxResultsPerRequest);
+            }
+            
+        } while (totalReturnedCount < result.TotalResults && totalReturnedCount < Options.Limit);
+
+        switch (Options.OutputFormat)
+        {
+            case OutputFormat.Simple:
+                OutputSimple(cpes);
+                break;
+            case OutputFormat.Json:
+                OutputJson(cpes);
+                break;
+            default:
+                throw new NotImplementedException();
+        }
+    }
+
+    private void OutputSimple(List<Cpe> cpes)
+    {
+        foreach (Cpe cpe in cpes)
+        {
+            _console.WriteLine($"Title:   {OutputHelper.GetValueForCurrentCulture(cpe.Titles)}");
+            _console.WriteLine($"CPE:     {cpe.CpeName}");
+            _console.WriteLine($"Created: {OutputHelper.FormatDate(cpe.Created)}");
+            _console.WriteLine(string.Empty);
+        }
+    }
+
+    private void OutputJson(List<Cpe> cpes)
+    {
+        string json = JsonSerializer.Serialize(cpes, _options);
+        _console.WriteLine(json);
+    }
+}

--- a/src/Valleysoft.NvdExplorer/Commands/CpeOptions.cs
+++ b/src/Valleysoft.NvdExplorer/Commands/CpeOptions.cs
@@ -1,0 +1,29 @@
+﻿using System.CommandLine;
+
+namespace Valleysoft.NvdExplorer.Commands;
+
+internal class CpeOptions : OptionsBase
+{
+    private readonly Option<string> _keywordSearchOption;
+    private readonly Option<bool> _keywordExactMatchOption;
+
+    public string? KeywordSearch { get; set; }
+
+    public bool IsKeywordExactMatch { get; set; }
+
+
+    public CpeOptions()
+    {
+        const string KeywordsOptionName = "--keywords";
+
+        _keywordSearchOption = Add(new Option<string>(KeywordsOptionName, "Returns CVEs that contain the provided keywords in the description"));
+        _keywordExactMatchOption = Add(new Option<bool>("--exact-match", $"Modifies the keyword search to find an exact match (must be used with {KeywordsOptionName})"));
+    }
+
+    protected override void GetValues()
+    {
+        base.GetValues();
+        KeywordSearch = GetValue(_keywordSearchOption);
+        IsKeywordExactMatch = GetValue(_keywordExactMatchOption);
+    }
+}

--- a/src/Valleysoft.NvdExplorer/Commands/CveCommand.cs
+++ b/src/Valleysoft.NvdExplorer/Commands/CveCommand.cs
@@ -52,6 +52,32 @@ internal class CveCommand(NvdClient client, IConsole console) : CommandWithOptio
             
         } while (totalReturnedCount < result.TotalResults && totalReturnedCount < Options.Limit);
 
+        switch (Options.OutputFormat)
+        {
+            case OutputFormat.Simple:
+                OutputSimple(vulnerabilities);
+                break;
+            case OutputFormat.Json:
+                OutputJson(vulnerabilities);
+                break;
+            default:
+                throw new NotImplementedException();
+        }
+    }
+
+    private void OutputSimple(List<Cve> vulnerabilities)
+    {
+        foreach (var vuln in vulnerabilities)
+        {
+            _console.WriteLine($"CVE:         {vuln.Id}");
+            _console.WriteLine($"Description: {OutputHelper.GetValueForCurrentCulture(vuln.Descriptions)}");
+            _console.WriteLine($"Published:   {OutputHelper.FormatDate(vuln.Published)}");
+            _console.WriteLine(string.Empty);
+        }
+    }
+
+    private void OutputJson(List<Cve> vulnerabilities)
+    {
         string json = JsonSerializer.Serialize(vulnerabilities, _options);
         _console.WriteLine(json);
     }

--- a/src/Valleysoft.NvdExplorer/Commands/CveOptions.cs
+++ b/src/Valleysoft.NvdExplorer/Commands/CveOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System.CommandLine;
-using System.Runtime.CompilerServices;
 using Valleysoft.Nvd.Client;
 
 namespace Valleysoft.NvdExplorer.Commands;
@@ -24,8 +23,6 @@ internal class CveOptions : OptionsBase
     private readonly Option<bool> _isVulnerableOption;
     private readonly Option<string> _keywordSearchOption;
     private readonly Option<bool> _keywordExactMatchOption;
-
-    public int? Limit { get; set; }
 
     public string? Cpe { get; set; }
 
@@ -65,8 +62,6 @@ internal class CveOptions : OptionsBase
         const string CpeOptionName = "--cpe";
         const string KeywordsOptionName = "--keywords";
 
-
-        _limitOption = Add(new Option<int?>("--limit", "Maximum number of CVEs to include in the result"));
         _cpeOption = Add(new Option<string?>(CpeOptionName, "Returns CVEs associated with a specific Common Platform Enumeration (CPE) name"));
         _idOption = Add(new Option<string?>("--cve", "Returns a CVE by its CVE ID"));
         _tagOption = Add(new Option<string?>("--tag", "Returns CVEs that include the provided tag"));
@@ -88,7 +83,7 @@ internal class CveOptions : OptionsBase
 
     protected override void GetValues()
     {
-        Limit = GetValue(_limitOption);
+        base.GetValues();
         Cpe = GetValue(_cpeOption);
         Id = GetValue(_idOption);
         Tag = GetValue(_tagOption);

--- a/src/Valleysoft.NvdExplorer/Commands/OptionsBase.cs
+++ b/src/Valleysoft.NvdExplorer/Commands/OptionsBase.cs
@@ -1,4 +1,5 @@
-﻿using System.CommandLine;
+﻿using System.Collections.Generic;
+using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.Diagnostics.CodeAnalysis;
 
@@ -6,9 +7,21 @@ namespace Valleysoft.NvdExplorer.Commands;
 
 public abstract class OptionsBase
 {
+    private readonly Option<OutputFormat> _outputFormatOption;
+    private readonly Option<int?> _limitOption;
     private readonly List<Argument> _arguments = [];
     private readonly List<Option> _options = [];
     private ParseResult? _parseResult;
+
+    protected OptionsBase()
+    {
+        _outputFormatOption = Add(new Option<OutputFormat>("--format", () => OutputFormat.Simple, "Set the format of the output"));
+        _limitOption = Add(new Option<int?>("--limit", "Maximum number of CVEs to include in the result"));
+    }
+
+    public OutputFormat OutputFormat { get; set; } = OutputFormat.Simple;
+
+    public int? Limit { get; set; }
 
     protected Argument<T> Add<T>(Argument<T> argument)
     {
@@ -49,7 +62,11 @@ public abstract class OptionsBase
         GetValues();
     }
 
-    protected abstract void GetValues();
+    protected virtual void GetValues()
+    {
+        OutputFormat = GetValue(_outputFormatOption);
+        Limit = GetValue(_limitOption);
+    }
 
     public void SetCommandOptions(Command cmd)
     {
@@ -63,5 +80,11 @@ public abstract class OptionsBase
             cmd.AddOption(option);
         }
     }
+}
+
+public enum OutputFormat
+{
+    Simple,
+    Json
 }
 

--- a/src/Valleysoft.NvdExplorer/Commands/OutputHelper.cs
+++ b/src/Valleysoft.NvdExplorer/Commands/OutputHelper.cs
@@ -1,0 +1,36 @@
+﻿using System.Globalization;
+using Valleysoft.Nvd.Client;
+
+namespace Valleysoft.NvdExplorer.Commands;
+
+internal static class OutputHelper
+{
+    public static string FormatDate(DateTimeOffset dateTime) =>
+        dateTime.ToLocalTime().ToString("d");
+
+    public static string GetValueForCurrentCulture(IEnumerable<ILanguageValue> languageValues)
+    {
+        ILanguageValue? langVal = languageValues
+            .FirstOrDefault(title => IsCultureDerivedFromCurrentCulture(title));
+
+        return langVal?.Value ?? languageValues.First().Value;
+    }
+
+    private static bool IsCultureDerivedFromCurrentCulture(ILanguageValue languageValue) =>
+        IsSourceCultureDerivedFromTargetCulture(CultureInfo.CurrentCulture, CultureInfo.GetCultureInfo(languageValue.Language));
+
+    private static bool IsSourceCultureDerivedFromTargetCulture(CultureInfo sourceCulture, CultureInfo targetCulture)
+    {
+        if (targetCulture.Name == sourceCulture.Name)
+        {
+            return true;
+        }
+
+        if (sourceCulture.Parent != CultureInfo.InvariantCulture)
+        {
+            return IsSourceCultureDerivedFromTargetCulture(sourceCulture.Parent, targetCulture);
+        }
+
+        return false;
+    }
+}

--- a/src/Valleysoft.NvdExplorer/Program.cs
+++ b/src/Valleysoft.NvdExplorer/Program.cs
@@ -10,7 +10,8 @@ SystemConsole console = new();
 
 RootCommand rootCommand = new("CLI for querying National Vulnerability Database (NVD)")
 {
-    new CveCommand(client, console)
+    new CveCommand(client, console),
+    new CpeCommand(client, console)
 };
 
 return rootCommand.Invoke(args);

--- a/src/Valleysoft.NvdExplorer/Properties/launchSettings.json
+++ b/src/Valleysoft.NvdExplorer/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "Valleysoft.NvdExplorer": {
-        "commandName": "Project",
-        "commandLineArgs": "cve --limit 5 --cvss-v4 AV:A/AC:H/PR:H/UI:N"
-    }
-  }
-}


### PR DESCRIPTION
Defines a `cpe` command that provides a command-line interface for querying the National Vulnerability Database (NVD) for Common Vulnerabilities and Exposures (CVE) data.

Only a partial set of the options are currently defined amongst the full set of filters available from the REST API.